### PR TITLE
feat(login): loginSelector not mandatory

### DIFF
--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -161,7 +161,7 @@ async function baseLoginConnect(typeUsername, typePassword, authorizeApp, option
   )
 
   await page.goto(options.loginUrl)
-  await login({page, options})
+  options.loginSelector && (await login({page, options}))
 
   // Switch to Popup Window
   if (options.isPopup) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

There could be the case when we do not want to select the social login link.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context

Suppose the next use case: only one social login (google or facebook) is used, so, when no cookie is present the user is redirected automatically to sign in. There's no need for an intermediate step to select the only social login.

## How Has This Been Tested?

I tested form the forked repo.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
